### PR TITLE
Add Kelvin temperature conversion and update forecast display

### DIFF
--- a/SampleApp/FrontEnd/Data/WeatherForecast.cs
+++ b/SampleApp/FrontEnd/Data/WeatherForecast.cs
@@ -8,6 +8,8 @@ namespace FrontEnd.Data
 
         public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
 
+        public double TemperatureK => TemperatureC + 273.15;
+
         public string? Summary { get; set; }
     }
 }

--- a/SampleApp/FrontEnd/Data/WeatherForecastClient.cs
+++ b/SampleApp/FrontEnd/Data/WeatherForecastClient.cs
@@ -12,6 +12,6 @@ namespace FrontEnd.Data
         }
 
         public async Task<WeatherForecast[]> GetForecastAsync(DateTime? startDate)
-            => await _httpClient.GetFromJsonAsync<WeatherForecast[]>($"WeatherForecast?startDate={startDate}");
+            => (await _httpClient.GetFromJsonAsync<WeatherForecast[]>($"WeatherForecast?startDate={startDate}")) ?? Array.Empty<WeatherForecast>();
     }
 }

--- a/SampleApp/FrontEnd/Pages/FetchData.razor
+++ b/SampleApp/FrontEnd/Pages/FetchData.razor
@@ -20,6 +20,7 @@ else
                 <th>Date</th>
                 <th>Temp. (C)</th>
                 <th>Temp. (F)</th>
+                <th>Temp. (K)</th>
                 <th>Summary</th>
             </tr>
         </thead>
@@ -30,6 +31,7 @@ else
                     <td>@forecast.Date.ToShortDateString()</td>
                     <td>@forecast.TemperatureC</td>
                     <td>@forecast.TemperatureF</td>
+                    <td>@forecast.TemperatureK</td>
                     <td>@forecast.Summary</td>
                 </tr>
             }


### PR DESCRIPTION
This pull request includes several changes to the `SampleApp` project to add temperature in Kelvin and improve the handling of null responses from the `WeatherForecastClient`. The most important changes are listed below:

### New Feature: Temperature in Kelvin

* [`SampleApp/FrontEnd/Data/WeatherForecast.cs`](diffhunk://#diff-9091e76fe68dee4af45bd6b51477cf41e392ca8bbd7efc46efe215e5e5d04161R11-R12): Added a new property `TemperatureK` to the `WeatherForecast` class to calculate temperature in Kelvin.
* [`SampleApp/FrontEnd/Pages/FetchData.razor`](diffhunk://#diff-a29dddb3d71338ddc717d1b5700c1361b5c50dc8c82a34769821124e547db758R23): Updated the table headers and data rows to include temperature in Kelvin. [[1]](diffhunk://#diff-a29dddb3d71338ddc717d1b5700c1361b5c50dc8c82a34769821124e547db758R23) [[2]](diffhunk://#diff-a29dddb3d71338ddc717d1b5700c1361b5c50dc8c82a34769821124e547db758R34)

### Improvement: Null Response Handling

* [`SampleApp/FrontEnd/Data/WeatherForecastClient.cs`](diffhunk://#diff-66693667174fe92513307f4de839f911d01cae040e94b21bb6c7c188b769adc0L15-R15): Modified the `GetForecastAsync` method to return an empty array if the HTTP response is null.