### PR TITLE
Add Kelvin temperature conversion to WeatherForecast model and update UI

### DIFF
--- a/SampleApp/BackEnd/Program.cs
+++ b/SampleApp/BackEnd/Program.cs
@@ -39,4 +39,5 @@ app.Run();
 internal record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
 {
     public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+    public double TemperatureK => TemperatureC + 273.15; // Add Kelvin conversion
 }

--- a/SampleApp/FrontEnd/Data/WeatherForecast.cs
+++ b/SampleApp/FrontEnd/Data/WeatherForecast.cs
@@ -8,6 +8,8 @@ namespace FrontEnd.Data
 
         public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
 
+        public double TemperatureK => TemperatureC + 273.15; // Add Kelvin conversion
+
         public string? Summary { get; set; }
     }
 }

--- a/SampleApp/FrontEnd/Pages/FetchData.razor
+++ b/SampleApp/FrontEnd/Pages/FetchData.razor
@@ -20,6 +20,7 @@ else
                 <th>Date</th>
                 <th>Temp. (C)</th>
                 <th>Temp. (F)</th>
+                <th>Temp. (K)</th> <!-- Add Kelvin column -->
                 <th>Summary</th>
             </tr>
         </thead>
@@ -30,6 +31,7 @@ else
                     <td>@forecast.Date.ToShortDateString()</td>
                     <td>@forecast.TemperatureC</td>
                     <td>@forecast.TemperatureF</td>
+                    <td>@forecast.TemperatureK</td> <!-- Display Kelvin -->
                     <td>@forecast.Summary</td>
                 </tr>
             }


### PR DESCRIPTION
This pull request introduces a new feature to display temperature in Kelvin in the `SampleApp`. The changes span across both the backend and frontend components of the application to ensure consistency in functionality and display.

### Backend changes:
* Added a property `TemperatureK` to the `WeatherForecast` record in `Program.cs` to calculate and provide the temperature in Kelvin.

### Frontend changes:
* Added a property `TemperatureK` to the `WeatherForecast` class in `WeatherForecast.cs` to calculate and provide the temperature in Kelvin.
* Updated `FetchData.razor` to include a new column for displaying temperature in Kelvin in the table header.
* Updated `FetchData.razor` to display the temperature in Kelvin for each weather forecast entry in the table rows.