### PR TITLE
Add TemperatureK property and update UI to display Kelvin

### DIFF
--- a/SampleApp/BackEnd/Program.cs
+++ b/SampleApp/BackEnd/Program.cs
@@ -39,4 +39,5 @@ app.Run();
 internal record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
 {
     public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+    public double TemperatureK => TemperatureC + 273.15; // Added property for Kelvin
 }

--- a/SampleApp/FrontEnd/Data/WeatherForecast.cs
+++ b/SampleApp/FrontEnd/Data/WeatherForecast.cs
@@ -8,6 +8,8 @@ namespace FrontEnd.Data
 
         public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
 
+        public double TemperatureK => TemperatureC + 273.15; // Added property for Kelvin
+
         public string? Summary { get; set; }
     }
 }

--- a/SampleApp/FrontEnd/Pages/FetchData.razor
+++ b/SampleApp/FrontEnd/Pages/FetchData.razor
@@ -20,6 +20,7 @@ else
                 <th>Date</th>
                 <th>Temp. (C)</th>
                 <th>Temp. (F)</th>
+                <th>Temp. (K)</th> <!-- Added column for Kelvin -->
                 <th>Summary</th>
             </tr>
         </thead>
@@ -30,6 +31,7 @@ else
                     <td>@forecast.Date.ToShortDateString()</td>
                     <td>@forecast.TemperatureC</td>
                     <td>@forecast.TemperatureF</td>
+                    <td>@forecast.TemperatureK</td> <!-- Display Kelvin -->
                     <td>@forecast.Summary</td>
                 </tr>
             }


### PR DESCRIPTION
This pull request introduces changes to the `WeatherForecast` class and associated frontend components to include temperature in Kelvin. The most important changes include adding a new property for Kelvin in both backend and frontend, and updating the UI to display the Kelvin temperature.

Backend changes:

* [`SampleApp/BackEnd/Program.cs`](diffhunk://#diff-7a007df117756abb41880d5f2732103bc9248be3cca9f070e47bd19918d73a70R42): Added a new property `TemperatureK` to the `WeatherForecast` record to calculate temperature in Kelvin.

Frontend changes:

* [`SampleApp/FrontEnd/Data/WeatherForecast.cs`](diffhunk://#diff-9091e76fe68dee4af45bd6b51477cf41e392ca8bbd7efc46efe215e5e5d04161R11-R12): Added a new property `TemperatureK` to the `WeatherForecast` class to calculate temperature in Kelvin.
* [`SampleApp/FrontEnd/Pages/FetchData.razor`](diffhunk://#diff-a29dddb3d71338ddc717d1b5700c1361b5c50dc8c82a34769821124e547db758R23): Added a new column for Kelvin temperature in the table header.
* [`SampleApp/FrontEnd/Pages/FetchData.razor`](diffhunk://#diff-a29dddb3d71338ddc717d1b5700c1361b5c50dc8c82a34769821124e547db758R34): Updated the table rows to display the Kelvin temperature.