### PR TITLE
Add TemperatureK property and update FetchData to display Kelvin

### DIFF
--- a/SampleApp/BackEnd/Program.cs
+++ b/SampleApp/BackEnd/Program.cs
@@ -39,4 +39,5 @@ app.Run();
 internal record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
 {
     public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+    public double TemperatureK => TemperatureC + 273.15;
 }

--- a/SampleApp/FrontEnd/Data/WeatherForecast.cs
+++ b/SampleApp/FrontEnd/Data/WeatherForecast.cs
@@ -4,10 +4,13 @@ namespace FrontEnd.Data
     {
         public DateOnly Date { get; set; }
 
-        public int TemperatureC { get; set; }
+        public int tempCelsius { get; set; }
 
-        public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+        public int TemperatureF => 32 + (int)(tempCelsius / 0.5556);
+        public double TemperatureK => tempCelsius + 273.15;
 
         public string? Summary { get; set; }
+
+        public string? SummaryIcon { get; set; }
     }
 }

--- a/SampleApp/FrontEnd/Pages/FetchData.razor
+++ b/SampleApp/FrontEnd/Pages/FetchData.razor
@@ -20,6 +20,7 @@ else
                 <th>Date</th>
                 <th>Temp. (C)</th>
                 <th>Temp. (F)</th>
+                <th>Temp. (K)</th>
                 <th>Summary</th>
             </tr>
         </thead>
@@ -30,6 +31,7 @@ else
                     <td>@forecast.Date.ToShortDateString()</td>
                     <td>@forecast.TemperatureC</td>
                     <td>@forecast.TemperatureF</td>
+                    <td>@forecast.TemperatureK</td>
                     <td>@forecast.Summary</td>
                 </tr>
             }


### PR DESCRIPTION
This pull request introduces enhancements to the weather forecast functionality by adding support for Kelvin temperature, renaming a property for consistency, and extending the UI to display the new data. Below are the most important changes grouped by theme:

### Backend Enhancements:
* Added a `TemperatureK` property to the `WeatherForecast` record in `Program.cs` to calculate temperature in Kelvin.

### Frontend Enhancements:
* Renamed the `TemperatureC` property to `tempCelsius` in the `WeatherForecast` class for consistency with naming conventions.
* Added a `TemperatureK` property to the `WeatherForecast` class to support Kelvin temperature.
* Introduced a new `SummaryIcon` property to the `WeatherForecast` class, likely for future use in displaying icons alongside summaries.

### UI Updates:
* Updated the `FetchData.razor` table to include a new column for displaying temperature in Kelvin (`Temp. (K)`). [[1]](diffhunk://#diff-a29dddb3d71338ddc717d1b5700c1361b5c50dc8c82a34769821124e547db758R23) [[2]](diffhunk://#diff-a29dddb3d71338ddc717d1b5700c1361b5c50dc8c82a34769821124e547db758R34)